### PR TITLE
Default iconv if no headers passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,13 @@ function GettextDomain(textdomain){
     
     this.charset = "iso-8859-1";
     this.headers = false;
-    
+
+    this.iconv = {
+        convert: function(data){
+            return data;
+        }
+    }
+
     if(this.total){
         this.load_tables();
     }


### PR DESCRIPTION
Without this I'm getting error:

```
TypeError: Cannot call method 'convert' of undefined
    at GettextDomain.handle_strings (/home/bobrik/vokrug-server/node_modules/node-gettext/index.js:77:24)
    at GettextDomain.load_tables (/home/bobrik/vokrug-server/node_modules/node-gettext/index.js:66:14)
    at new GettextDomain (/home/bobrik/vokrug-server/node_modules/node-gettext/index.js:25:14)
    at Gettext.addTextdomain (/home/bobrik/vokrug-server/node_modules/node-gettext/index.js:221:28)
    at Object.getText (/home/bobrik/vokrug-server/node_modules/vokrug/Translate/Translator.js:29:21)
    at Object.translate (/home/bobrik/vokrug-server/node_modules/vokrug/Translate/Translator.js:40:21)
```
