### PR TITLE
upgrade iconv

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         }
     ],
     "dependencies": {
-        "iconv":"1.1.3"
+        "iconv":">=1.2.0"
     },
     "devDependencies": {
         "nodeunit": "*"


### PR DESCRIPTION
Upgraded the version of iconv so that at least the version is used after migration from node-waf to node-gyp.
The node version ">=0.6" should be fine.

Tested with node 0.10.1. iconv gives a lot of warnings no matter whether 1.2.4 or the newest one. I also tested a module depending on node-gettext: i18next-gettext-converter, and it works fine.

Related to:
https://github.com/andris9/node-gettext/pull/11

This would be helping to fix:
https://github.com/jamuhl/i18next-gettext-converter/issues/4
