### PR TITLE
support flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The function also returns the current texdomain value
 
     gt.getComment("et", "menu items", "%d Recent File");
 
-Returns an object in the form of `{comment: "", code: "", note: ""}`
+Returns an object in the form of `{comment: "", code: "", note: "", flag: ""}`
 
 ### Sets a comments for a translation
 
@@ -129,7 +129,7 @@ Returns an object in the form of `{comment: "", code: "", note: ""}`
 
     gt.getComment("et", "menu items", "%d Recent File", "This is a comment");
 
-`comment` can either be a string or an object with the following properties: `{comment: "", code: "", note: ""}`.
+`comment` can either be a string or an object with the following properties: `{comment: "", code: "", note: "", flag: ""}`.
 
 ## String helpers
 

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -556,6 +556,9 @@ GettextDomain.prototype.compilePO = function(){
             if(line.comment.code){
                 returnStr += "#: " + line.comment.code.replace(/\r?\n|\r/g, "\n#: ") + "\n";
             }
+            if(line.comment.flag){
+                returnStr += "#, " + line.comment.flag.replace(/\r?\n|\r/g, "\n#, ") + "\n";
+            }
         }
 
         if(line.context){

--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -173,7 +173,7 @@ Gettext.prototype.dnpgettext = function(domain, context, msgid, msgidPlural, cou
  * @param {String} domain Case insensitive language identifier
  * @param {String} context Translation context
  * @param {String} msgid String to be translated
- * @return {Object} comments for the translation in the form of {comment, note, code}
+ * @return {Object} comments for the translation in the form of {comment, note, code, flag}
  */
 Gettext.prototype.getComment = function(domain, context, msgid){
     domain = (domain || this._textdomain || "").toLowerCase().trim();
@@ -190,7 +190,7 @@ Gettext.prototype.getComment = function(domain, context, msgid){
  * @param {String} domain Case insensitive language identifier
  * @param {String} context Translation context
  * @param {String} msgid String to be translated
- * @return {String|Object} comment for the translation in the form of {comment, note, code} or a string
+ * @return {String|Object} comment for the translation in the form of {comment, note, code, flag} or a string
  */
 Gettext.prototype.setComment = function(domain, context, msgid, comment){
     domain = (domain || this._textdomain || "").toLowerCase().trim();

--- a/lib/poparser.js
+++ b/lib/poparser.js
@@ -187,7 +187,7 @@ POParser.prototype.parse = function(){
         var comment, lines;
 
         if(node && node.type == this.types.comments){
-            comment = {code: [], comment: [], note: []};
+            comment = {code: [], comment: [], note: [], flag: []};
             lines = (node.value || "").split(/\n/);
             lines.forEach(function(line){
                 switch(line.charAt(0) || ""){
@@ -196,6 +196,9 @@ POParser.prototype.parse = function(){
                         break;
                     case ".":
                         comment.note.push(line.substr(1).replace(/^\s+/, ""));
+                        break;
+                    case ",":
+                        comment.flag.push(line.substr(1).replace(/^\s+/, ""));
                         break;
                     default:
                         comment.comment.push(line.replace(/^\s+/, ""));
@@ -214,6 +217,10 @@ POParser.prototype.parse = function(){
 
             if(comment.code.length){
                 node.value.code = comment.code.join("\n");
+            }
+
+            if(comment.flag.length){
+                node.value.flag = comment.flag.join("\n");
             }
         }
     }).bind(this));

--- a/test/comments.po
+++ b/test/comments.po
@@ -14,5 +14,7 @@ msgstr ""
 #. Editors note line 2
 #: /absolute/path:13
 #: /absolute/path:14
+#, fuzzy
+#, c-format
 msgid "test"
 msgstr "test"

--- a/test/gettext.js
+++ b/test/gettext.js
@@ -458,7 +458,8 @@ exports["COMMENTS"] = {
             {
                 comment: 'Normal comment line 1\nNormal comment line 2',
                 note: 'Editors note line 1\nEditors note line 2',
-                code: '/absolute/path:13\n/absolute/path:14' 
+                code: '/absolute/path:13\n/absolute/path:14',
+                flag: 'fuzzy\nc-format'
             });
         test.done();
     },
@@ -468,7 +469,8 @@ exports["COMMENTS"] = {
             {
                 comment: 'tere',
                 note: 'Editors note line 1\nEditors note line 2',
-                code: '/absolute/path:13\n/absolute/path:14' 
+                code: '/absolute/path:13\n/absolute/path:14' ,
+                flag: 'fuzzy\nc-format'
             });
         test.done();
     },
@@ -478,7 +480,8 @@ exports["COMMENTS"] = {
             {
                 comment: 'tere',
                 note: 'Editors note line 1\nEditors note line 2',
-                code: '/absolute/path:13\n/absolute/path:14' 
+                code: '/absolute/path:13\n/absolute/path:14' ,
+                flag: 'fuzzy\nc-format'
             });
         test.done();
     },
@@ -488,7 +491,8 @@ exports["COMMENTS"] = {
             {
                 comment: 'Normal comment line 1\nNormal comment line 2',
                 note: 'tere',
-                code: '/absolute/path:13\n/absolute/path:14' 
+                code: '/absolute/path:13\n/absolute/path:14',
+                flag: 'fuzzy\nc-format'
             });
         test.done();
     },
@@ -498,7 +502,19 @@ exports["COMMENTS"] = {
             {
                 comment: 'Normal comment line 1\nNormal comment line 2',
                 note: 'Editors note line 1\nEditors note line 2',
-                code: '/abs:1' 
+                code: '/abs:1',
+                flag: 'fuzzy\nc-format'
+            });
+        test.done();
+    },
+    "Set comment object for flag": function(test){
+        this.g.setComment("et", "", "test", {flag: "something"});
+        test.deepEqual(this.g.getComment("et", "", "test"),
+            {
+                comment: 'Normal comment line 1\nNormal comment line 2',
+                note: 'Editors note line 1\nEditors note line 2',
+                code: '/absolute/path:13\n/absolute/path:14',
+                flag: 'something'
             });
         test.done();
     },
@@ -508,7 +524,8 @@ exports["COMMENTS"] = {
             {
                 comment: 'Normal comment line 1\nNormal comment line 2',
                 note: 'Editors note line 1\nEditors note line 2',
-                code: '/absolute/path:13\n/absolute/path:14' 
+                code: '/absolute/path:13\n/absolute/path:14',
+                flag: 'fuzzy\nc-format'
             });
         test.done();
     }


### PR DESCRIPTION
This adds support for flags (`#, flag...`), as pr. the gettext spec. I have added tests and updated the documentation. Flags are supported the same way as the other comment-style fields, by adding a property to the comment object - so now it is `{ comment, code, note, flag }`.
