### PR TITLE
Change API to behave more like gettext

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ var gt = new Gettext();
 
 ### Add a language
 
+*loadTextdomainDirectory(domain, directory)*
+
+Load from a *MO* file
+
+```js
+gt.setlocale('de_DE');
+var fileDirectory = './locale/message/';
+gt.addTextdomain("message", fileDirectory); 
+// loads ./locale/message/de_DE.mo or ./locale/message/de.mo
+```
+
+Plural rules are automatically detected from the language code
+
+### Add a language
+
 *addTextdomain(domain, file)*
 
 Language data needs to be in the Buffer format - it can be either contents of a *MO* or *PO* file.
@@ -40,29 +55,43 @@ Load from a *MO* file
 
 ```js
 var fileContents = fs.readFileSync("et.mo");
-gt.addTextdomain("et", fileContents);
+gt.addTextdomain("message", fileContents);
 ```
 
 or load from a *PO* file
 
 ```js
 var fileContents = fs.readFileSync("et.po");
-gt.addTextdomain("et", fileContents);
+gt.addTextdomain("message", fileContents);
 ```
 
 Plural rules are automatically detected from the language code
 
 ```js
-gt.addTextdomain("et");
-gt.setTranslation("et", false, "hello!", "tere!");
+gt.addTextdomain("message");
+gt.setTranslation("message", false, "hello!", "tere!");
 ```
 
-### Check or change default language
+### Check or change default locale
+
+*setlocale(locale)*
+
+```js
+gt.setlocale("de");
+```
+
+The function also returns the current locale value
+
+```js
+var curlang = gt.getLocale();
+```
+
+### Check or change default domain
 
 *textdomain(domain)*
 
 ```js
-gt.textdomain("et");
+gt.textdomain("message");
 ```
 
 The function also returns the current texdomain value
@@ -86,7 +115,7 @@ var greeting = gt.gettext("Hello!");
 *dgettext(domain, msgid)*
 
 ```js
-var greeting = gt.dgettext("et", "Hello!");
+var greeting = gt.dgettext("message", "Hello!");
 ```
 
 ### Load a plural string from default language file
@@ -102,7 +131,7 @@ gt.ngettext("%d Comment", "%d Comments", 10);
 *dngettext(domain, msgid, msgid_plural, count)*
 
 ```js
-gt.dngettext("et", "%d Comment", "%d Comments", 10);
+gt.dngettext("message", "%d Comment", "%d Comments", 10);
 ```
 
 ### Load a string of a specific context
@@ -118,7 +147,7 @@ gt.pgettext("menu items", "File");
 *dpgettext(domain, msgctxt, msgid)*
 
 ```js
-gt.dpgettext("et", "menu items", "File");
+gt.dpgettext("message", "menu items", "File");
 ```
 
 ### Load a plural string of a specific context
@@ -134,7 +163,7 @@ gt.npgettext("menu items", "%d Recent File", "%d Recent Files", 3);
 *dnpgettext(domain, msgctxt, msgid, msgid_plural, count)*
 
 ```js
-gt.dnpgettext("et", "menu items", "%d Recent File", "%d Recent Files", 3);
+gt.dnpgettext("message", "menu items", "%d Recent File", "%d Recent Files", 3);
 ```
 
 ### Get comments for a translation (if loaded from PO)
@@ -142,14 +171,14 @@ gt.dnpgettext("et", "menu items", "%d Recent File", "%d Recent Files", 3);
 *getComment(domain, msgctxt, msgid)*
 
 ```js
-gt.getComment("et", "menu items", "%d Recent File");
+gt.getComment("message", "menu items", "%d Recent File");
 ```
 
 Returns an object in the form of `{translator: "", extracted: "", reference: "", flag: "", previous: ""}`
 
 ## Advanced handling
 
-If you need the translation object for a domain, for example `et_EE`, you can access it from `gt.domains.et_EE`.
+If you need the translation object for a domain, for example `message`, you can access it from `gt.domains.message`.
 
 If you want modify it and compile it to *mo* or *po*, checkout [gettext-parser](https://github.com/andris9/gettext-parser) module.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Load from a *MO* file
 ```js
 gt.setlocale('de_DE');
 var fileDirectory = './locale/message/';
-gt.addTextdomain("message", fileDirectory); 
+gt.loadTextdomainDirectory("message", fileDirectory);
 // loads ./locale/message/de_DE.mo or ./locale/message/de.mo
 ```
 
@@ -80,11 +80,7 @@ gt.setTranslation("message", false, "hello!", "tere!");
 gt.setlocale("de");
 ```
 
-The function also returns the current locale value
-
-```js
-var curlang = gt.getLocale();
-```
+Unlike the C interface, this function does not return the current locale value. This might change in the future.
 
 ### Check or change default domain
 

--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -13,6 +13,35 @@ module.exports = Gettext;
 function Gettext() {
     this.domains = {};
     this._currentDomain = false;
+
+    // default plurals to EN rules
+    this._pluralsInfo = plurals.en;
+    this._pluralsFunc = plurals.en.pluralsFunc;
+}
+
+function normalizeLocale(locale, isShort) {
+    var parts = (locale || '').toString().split('.').shift().split(/[\-_]/);
+    var language = (parts.shift() || '').toLowerCase();
+    var country = (parts.join('-') || '').toUpperCase();
+
+    if (isShort) {
+        return language;
+    } else {
+        return [].concat(language || []).concat(country || []).join('_');
+    }
+}
+
+/**
+ * Set the locale of this gettext instance, and loads relevant plural rules.
+ */
+Gettext.prototype.setlocale = function(locale) {
+    // We do not want to parse and compile stuff from unknown sources
+    // so we only use precompiled plural definitions
+    var pluralsInfo = plurals[normalizeLocale(locale, true)];
+    if (pluralsInfo) {
+        this._pluralsInfo = pluralsInfo;
+        this._pluralsFunc = this._pluralsInfo.pluralsFunc;
+    }
 }
 
 /**
@@ -23,7 +52,6 @@ function Gettext() {
  * @param {Buffer} fileContents Translations file (*.mo) contents as a Buffer object
  */
 Gettext.prototype.addTextdomain = function(domain, file) {
-    domain = this._normalizeDomain(domain);
     var translation;
 
     if (file && file.translations) {
@@ -37,16 +65,8 @@ Gettext.prototype.addTextdomain = function(domain, file) {
         translation = gettextParser.po.parse(file || '', 'utf-8');
     }
 
-    // We do not want to parse and compile stuff from unknown sources
-    // so we only use precompiled plural definitions
-    var pluralsInfo = plurals[this._normalizeDomain(domain, true)];
-    if (pluralsInfo && translation.headers) {
-        translation.headers['plural-forms'] = pluralsInfo.pluralsText;
-        translation.pluralsFunc = pluralsInfo.pluralsFunc;
-    } else {
-        // default plurals to EN rules
-        translation.pluralsFunc = plurals.en.pluralsFunc;
-    }
+    if (translation.headers)
+        translation.headers['plural-forms'] = this._pluralsInfo.pluralsText;
 
     this.domains[domain] = translation;
 
@@ -66,7 +86,6 @@ Gettext.prototype.textdomain = function(updatedDomain) {
         return this._currentDomain;
     }
 
-    updatedDomain = this._normalizeDomain(updatedDomain);
     if (this._currentDomain !== updatedDomain && this.domains.hasOwnProperty(updatedDomain)) {
         this._currentDomain = updatedDomain;
         return true;
@@ -172,7 +191,6 @@ Gettext.prototype.dnpgettext = function(domain, msgctxt, msgid, msgidPlural, cou
     var translation;
     var index;
 
-    domain = this._normalizeDomain(domain);
     msgctxt = msgctxt || '';
 
     if (!isNaN(count) && count !== 1) {
@@ -182,7 +200,7 @@ Gettext.prototype.dnpgettext = function(domain, msgctxt, msgid, msgidPlural, cou
     translation = this._getTranslation(domain, msgctxt, msgid);
     if (translation) {
         if (typeof count === 'number') {
-            index = this.domains[domain].pluralsFunc(count);
+            index = this._pluralsFunc(count);
             if (typeof index === 'boolean') {
                 index = index ? 1 : 0;
             }
@@ -206,8 +224,6 @@ Gettext.prototype.dnpgettext = function(domain, msgctxt, msgid, msgidPlural, cou
 Gettext.prototype.getComment = function(domain, msgctxt, msgid) {
     var translation;
 
-    domain = this._normalizeDomain(domain);
-
     translation = this._getTranslation(domain, msgctxt, msgid);
     if (translation) {
         return translation.comments || {};
@@ -228,7 +244,6 @@ Gettext.prototype._getTranslation = function(domain, msgctxt, msgid) {
     var translation;
 
     msgctxt = msgctxt || '';
-    domain = this._normalizeDomain(domain);
 
     if (this.domains.hasOwnProperty(domain)) {
         if (this.domains[domain].translations && this.domains[domain].translations[msgctxt]) {
@@ -239,23 +254,4 @@ Gettext.prototype._getTranslation = function(domain, msgctxt, msgid) {
     }
 
     return false;
-};
-
-/**
- * Normalizes textdomain value
- *
- * @param {String} domain Textdomain
- * @param {Boolean} [isShort] If true then returns only language
- * @returns {String} Normalized textdomain
- */
-Gettext.prototype._normalizeDomain = function(domain, isShort) {
-    var parts = (domain || '').toString().split('.').shift().split(/[\-_]/);
-    var language = (parts.shift() || '').toLowerCase();
-    var locale = (parts.join('-') || '').toUpperCase();
-
-    if (isShort) {
-        return language;
-    } else {
-        return [].concat(language || []).concat(locale || []).join('_');
-    }
 };

--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -65,7 +65,7 @@ Gettext.prototype.setlocale = function(locale) {
  * Adds a gettext to the domains list. If default textdomain is not set, uses it
  * as default
  *
- * @param {String} domain Case insensitive language identifier (domain)
+ * @param {String} domain gettext domain
  * @param {Buffer} fileContents Translations file (*.mo) contents as a Buffer object
  */
 Gettext.prototype.addTextdomain = function(domain, file) {
@@ -92,10 +92,10 @@ Gettext.prototype.addTextdomain = function(domain, file) {
 };
 
 /**
- * Adds a gettext domain to the domains list, loading it from the cache
+ * Adds a gettext domain to the domains list, loading it from the disk
  *
- * @param {String} domain Case insensitive language identifier (domain)
- * @param {Buffer} fileContents Translations file (*.mo) contents as a Buffer object
+ * @param {String} domain gettext domain
+ * @param {String} filename Translations file name
  */
 Gettext.prototype.loadTextdomain = function(domain, filename) {
     var file;
@@ -113,9 +113,33 @@ Gettext.prototype.loadTextdomain = function(domain, filename) {
 };
 
 /**
+ * Adds a gettext domain to the domains list, loading it from a directory
+ * of files named as $locale.mo, eg it.mo or en_GB.mo
+ * This corresponds to the "uninstalled" layout of gettext files, with all
+ * files for one domain in one place, usually together with the code.
+ * OTOH, the installed layout is /usr/share/$locale/LC_MESSAGES/$domain.mo
+ *
+ * @param {String} domain gettext domain
+ * @param {String} modir directory containing translation (*.mo) files
+ */
+Gettext.prototype.loadTextdomainDirectory = function(domain, modir) {
+    var locale = this._locale.split(/[-_\.@]/);
+    var mo = modir + '/' + locale.join('_') + '.mo';
+
+    // lazy require fs so that the module works in the browser too
+    var fs = require('fs');
+    while (!fs.existsSync(mo) && locale.length) {
+        locale.pop();
+        mo = modir + '/' + locale.join('_') + '.mo';
+    }
+    this.loadTextdomain(domain, mo);
+}
+
+
+/**
  * Changes the current default textdomain
  *
- * @param {String} [domain] Case insensitive language identifier
+ * @param {String} [domain] gettext domain
  * @return {String} cuurent textdomain
  */
 Gettext.prototype.textdomain = function(updatedDomain) {
@@ -144,7 +168,7 @@ Gettext.prototype.gettext = function(msgid) {
 /**
  * Translates a string using a specific domain
  *
- * @param {String} domain Case insensitive language identifier
+ * @param {String} domain gettext domain
  * @param {String} msgid String to be translated
  * @return {String} translation or the original string if no translation was found
  */
@@ -167,7 +191,7 @@ Gettext.prototype.ngettext = function(msgid, msgidPlural, count) {
 /**
  * Translates a plural string using a specific textdomain
  *
- * @param {String} domain Case insensitive language identifier
+ * @param {String} domain gettext domain
  * @param {String} msgid String to be translated
  * @param {String} msgidPlural If no translation was found, return this on count!=1
  * @param {Number} count Number count for the plural
@@ -191,7 +215,7 @@ Gettext.prototype.pgettext = function(msgctxt, msgid) {
 /**
  * Translates a string from a specific context using s specific textdomain
  *
- * @param {String} domain Case insensitive language identifier
+ * @param {String} domain gettext domain
  * @param {String} msgctxt Translation context
  * @param {String} msgid String to be translated
  * @return {String} translation or the original string if no translation was found
@@ -216,7 +240,7 @@ Gettext.prototype.npgettext = function(msgctxt, msgid, msgidPlural, count) {
 /**
  * Translates a plural string from a specifi context using a specific textdomain
  *
- * @param {String} domain Case insensitive language identifier
+ * @param {String} domain gettext domain
  * @param {String} msgctxt Translation context
  * @param {String} msgid String to be translated
  * @param {String} msgidPlural If no translation was found, return this on count!=1
@@ -253,7 +277,7 @@ Gettext.prototype.dnpgettext = function(domain, msgctxt, msgid, msgidPlural, cou
 /**
  * Retrieves comments object for a translation
  *
- * @param {String} domain Case insensitive language identifier
+ * @param {String} domain gettext domain
  * @param {String} msgctxt Translation context
  * @param {String} msgid String to be translated
  * @return {Object} comments object or false if not found
@@ -272,7 +296,7 @@ Gettext.prototype.getComment = function(domain, msgctxt, msgid) {
 /**
  * Retrieves translation object from the domain and context
  *
- * @param {String} domain Case insensitive language identifier
+ * @param {String} domain gettext domain
  * @param {String} msgctxt Translation context
  * @param {String} msgid String to be translated
  * @return {Object} translation object or false if not found

--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -5,6 +5,20 @@ var gettextParser = require('gettext-parser');
 
 module.exports = Gettext;
 
+var _cache = {};
+
+function cacheFile(locale, filename, file) {
+    if (!_cache[locale])
+        _cache[locale] = {};
+    _cache[locale][filename] = file;
+}
+
+function tryCache(locale, filename) {
+    if (!_cache[locale])
+        return undefined;
+    return _cache[locale][filename];
+}
+
 /**
  * Gettext function
  *
@@ -12,6 +26,7 @@ module.exports = Gettext;
  */
 function Gettext() {
     this.domains = {};
+    this._locale = 'en_US';
     this._currentDomain = false;
 
     // default plurals to EN rules
@@ -35,6 +50,8 @@ function normalizeLocale(locale, isShort) {
  * Set the locale of this gettext instance, and loads relevant plural rules.
  */
 Gettext.prototype.setlocale = function(locale) {
+    this._locale = locale;
+
     // We do not want to parse and compile stuff from unknown sources
     // so we only use precompiled plural definitions
     var pluralsInfo = plurals[normalizeLocale(locale, true)];
@@ -56,8 +73,7 @@ Gettext.prototype.addTextdomain = function(domain, file) {
 
     if (file && file.translations) {
         translation = file;
-    }
-    else if (file && typeof file !== 'string') {
+    } else if (file && typeof file !== 'string') {
         translation = gettextParser.mo.parse(file, 'utf-8');
     }
 
@@ -73,6 +89,27 @@ Gettext.prototype.addTextdomain = function(domain, file) {
     if (!this._currentDomain) {
         this._currentDomain = domain;
     }
+};
+
+/**
+ * Adds a gettext domain to the domains list, loading it from the cache
+ *
+ * @param {String} domain Case insensitive language identifier (domain)
+ * @param {Buffer} fileContents Translations file (*.mo) contents as a Buffer object
+ */
+Gettext.prototype.loadTextdomain = function(domain, filename) {
+    var file;
+    if ((file = tryCache(this._locale, filename)) !== undefined)
+        return this.addTextdomain(domain, file);
+
+    // lazy require fs so that the module works in the browser too
+    var fs = require('fs');
+    file = fs.readFileSync(filename);
+    this.addTextdomain(domain, file);
+
+    // use the parsed version of the file in the cache (it's more
+    // efficient)
+    cacheFile(this._locale, filename, this.domains[domain]);
 };
 
 /**

--- a/test/gettext-test.js
+++ b/test/gettext-test.js
@@ -9,45 +9,39 @@ chai.config.includeStack = true;
 
 describe('Gettext', function() {
 
-    describe('#_normalizeDomain', function() {
-        it('should normalize domain key', function() {
-            var gt = new Gettext();
-
-            expect(gt._normalizeDomain('ab-cd_ef.utf-8')).to.equal('ab_CD-EF');
-            expect(gt._normalizeDomain('ab-cd_ef', true)).to.equal('ab');
-        });
-    });
-
     describe('#addTextdomain', function() {
 
         it('Should add from a mo file', function() {
             var gt = new Gettext();
+            gt.setlocale('et-EE');
             var moFile = fs.readFileSync(__dirname + '/fixtures/latin13.mo');
 
-            gt.addTextdomain('et-EE', moFile);
+            gt.addTextdomain('messages', moFile);
 
-            expect(gt.domains.et_EE).to.exist;
-            expect(gt.domains.et_EE.charset).to.equal('iso-8859-13');
+            expect(gt.domains.messages).to.exist;
+            expect(gt.domains.messages.charset).to.equal('iso-8859-13');
         });
 
         it('Should add from a po file', function() {
             var gt = new Gettext();
+            gt.setlocale('et-EE');
             var poFile = fs.readFileSync(__dirname + '/fixtures/latin13.po');
 
-            gt.addTextdomain('et-EE', poFile);
+            gt.addTextdomain('messages', poFile);
 
-            expect(gt.domains.et_EE).to.exist;
-            expect(gt.domains.et_EE.charset).to.equal('iso-8859-13');
+            expect(gt.domains.messages).to.exist;
+            expect(gt.domains.messages.charset).to.equal('iso-8859-13');
         });
 
         it('Should add from a json file', function() {
             var gt = new Gettext();
+            gt.setlocale('et-EE');
             var jsonFile = JSON.parse(fs.readFileSync(__dirname + '/fixtures/latin13.json'));
 
-            gt.addTextdomain('et-EE', jsonFile);
+            gt.addTextdomain('messages', jsonFile);
 
-            expect(gt.domains.et_EE).to.exist;
-            expect(gt.domains.et_EE.charset).to.equal('iso-8859-13');
+            expect(gt.domains.messages).to.exist;
+            expect(gt.domains.messages.charset).to.equal('iso-8859-13');
         });
 
     });
@@ -58,10 +52,10 @@ describe('Gettext', function() {
             var moFile = fs.readFileSync(__dirname + '/fixtures/latin13.mo');
 
             expect(gt.textdomain()).to.be.false;
-            gt.addTextdomain('et-EE', moFile);
-            expect(gt.textdomain()).to.equal('et_EE');
-            gt.addTextdomain('cd-EE', moFile);
-            expect(gt.textdomain()).to.equal('et_EE');
+            gt.addTextdomain('messages', moFile);
+            expect(gt.textdomain()).to.equal('messages');
+            gt.addTextdomain('messages', moFile);
+            expect(gt.textdomain()).to.equal('messages');
         });
 
         it('should change default domain', function() {
@@ -69,12 +63,12 @@ describe('Gettext', function() {
             var moFile = fs.readFileSync(__dirname + '/fixtures/latin13.mo');
 
             expect(gt.textdomain()).to.be.false;
-            gt.addTextdomain('et-EE', moFile);
-            expect(gt.textdomain()).to.equal('et_EE');
-            gt.addTextdomain('cd-EE', moFile);
-            expect(gt.textdomain()).to.equal('et_EE');
-            gt.textdomain('cd_EE');
-            expect(gt.textdomain()).to.equal('cd_EE');
+            gt.addTextdomain('messages', moFile);
+            expect(gt.textdomain()).to.equal('messages');
+            gt.addTextdomain('domain1', moFile);
+            expect(gt.textdomain()).to.equal('messages');
+            gt.textdomain('domain2');
+            expect(gt.textdomain()).to.equal('domain2');
         });
     });
 
@@ -83,37 +77,38 @@ describe('Gettext', function() {
 
         beforeEach(function() {
             gt = new Gettext();
+            gt.setlocale('et-EE');
             var poFile = fs.readFileSync(__dirname + '/fixtures/latin13.po');
-            gt.addTextdomain('et-EE', poFile);
+            gt.addTextdomain('messages', poFile);
         });
 
         describe('#dnpgettext', function() {
             it('should return default singular', function() {
-                expect(gt.dnpgettext('et_EE', '', '0 matches', 'multiple matches', 1)).to.equal('0 matches');
+                expect(gt.dnpgettext('messages', '', '0 matches', 'multiple matches', 1)).to.equal('0 matches');
             });
 
             it('should return default plural', function() {
-                expect(gt.dnpgettext('et_EE', '', '0 matches', 'multiple matches', 100)).to.equal('multiple matches');
+                expect(gt.dnpgettext('messages', '', '0 matches', 'multiple matches', 100)).to.equal('multiple matches');
             });
 
             it('should return singular match from default context', function() {
-                expect(gt.dnpgettext('et_EE', '', 'o2-1', 'o2-2', 1)).to.equal('t2-1');
+                expect(gt.dnpgettext('messages', '', 'o2-1', 'o2-2', 1)).to.equal('t2-1');
             });
 
             it('should return plural match from default context', function() {
-                expect(gt.dnpgettext('et_EE', '', 'o2-1', 'o2-2', 2)).to.equal('t2-2');
+                expect(gt.dnpgettext('messages', '', 'o2-1', 'o2-2', 2)).to.equal('t2-2');
             });
 
             it('should return singular match from selected context', function() {
-                expect(gt.dnpgettext('et_EE', 'c2', 'co2-1', 'co2-2', 1)).to.equal('ct2-1');
+                expect(gt.dnpgettext('messages', 'c2', 'co2-1', 'co2-2', 1)).to.equal('ct2-1');
             });
 
             it('should return plural match from selected context', function() {
-                expect(gt.dnpgettext('et_EE', 'c2', 'co2-1', 'co2-2', 2)).to.equal('ct2-2');
+                expect(gt.dnpgettext('messages', 'c2', 'co2-1', 'co2-2', 2)).to.equal('ct2-2');
             });
 
             it('should return singular match for non existing domain', function() {
-                expect(gt.dnpgettext('cccc', '', 'o2-1', 'o2-2', 1)).to.equal('o2-1');
+                expect(gt.dnpgettext('nonexisting', '', 'o2-1', 'o2-2', 1)).to.equal('o2-1');
             });
         });
 
@@ -125,7 +120,7 @@ describe('Gettext', function() {
 
         describe('#dgettext', function() {
             it('should return singular from default context', function() {
-                expect(gt.dgettext('et-ee', 'o2-1')).to.equal('t2-1');
+                expect(gt.dgettext('messages', 'o2-1')).to.equal('t2-1');
             });
         });
 
@@ -137,7 +132,7 @@ describe('Gettext', function() {
 
         describe('#dngettext', function() {
             it('should return plural from default context', function() {
-                expect(gt.dngettext('et-ee', 'o2-1', 'o2-2', 2)).to.equal('t2-2');
+                expect(gt.dngettext('messages', 'o2-1', 'o2-2', 2)).to.equal('t2-2');
             });
         });
 
@@ -149,7 +144,7 @@ describe('Gettext', function() {
 
         describe('#dpgettext', function() {
             it('should return singular from selected context', function() {
-                expect(gt.dpgettext('et-ee', 'c2', 'co2-1')).to.equal('ct2-1');
+                expect(gt.dpgettext('messages', 'c2', 'co2-1')).to.equal('ct2-1');
             });
         });
 
@@ -161,7 +156,7 @@ describe('Gettext', function() {
 
         describe('#getComment', function() {
             it('should return comments object', function() {
-                expect(gt.getComment('et-ee', '', 'test')).to.deep.equal({
+                expect(gt.getComment('messages', '', 'test')).to.deep.equal({
                     translator: 'Normal comment line 1\nNormal comment line 2',
                     extracted: 'Editors note line 1\nEditors note line 2',
                     reference: '/absolute/path:13\n/absolute/path:14',


### PR DESCRIPTION
The old node-gettext API was defective in that it fundamentally misunderstood the interaction of locale and domain (and made it impossible to have modular translations, unlike true gettext).

This patchset fixes that issue, and also adds convenience functions to load files from disk in a node environment. These files would be generated at install or publish time using msgfmt in package scripts.

I originally planned to keep my fork private and just refer to it by github url in the projects using it, but given that other people seem to be interested in the project, let's try merging the changes back.
I have not bumped the version in package.json, although that probably needs to be done.
