### PR TITLE
Update jsDoc for Gettext constructor.

### DIFF
--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -9,7 +9,7 @@ module.exports = Gettext;
  * Creates and returns a new Gettext instance.
  *
  * @constructor
- * @param  {Object}  options        A set of options
+ * @param  {Object}  [options]        A set of options
  * @param  {Boolean} options.debug  Whether to output debug info into the
  *                                  console.
  * @return {Object}  A Gettext instance


### PR DESCRIPTION
IDEs like WebStorm complain when `new Gettext()` is called without a param since the `options` param is not marked optional.