### PR TITLE
Add default locale option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Creates and returns a new Gettext instance.
 - `[options]`: <code>Object</code> - A set of options
     - `.debug`: <code>Boolean</code> - Whether to output debug info into the
                                  console.
+    - `.defaultLocale`: <code>String</code> - Locale for the default messages
+                                         defined in the source code.
 
 <a name="Gettext+on"></a>
 

--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -12,6 +12,8 @@ module.exports = Gettext;
  * @param  {Object}  [options]        A set of options
  * @param  {Boolean} options.debug  Whether to output debug info into the
  *                                  console.
+ * @param  {String}  options.defaultLocale  Locale for the default messages
+ *                                          defined in the source code.
  * @return {Object}  A Gettext instance
  */
 function Gettext(options) {
@@ -22,6 +24,15 @@ function Gettext(options) {
     this.domain = 'messages';
 
     this.listeners = [];
+
+    // Set default locale
+    if (typeof options.defaultLocale === 'string') {
+        this.defaultLocale = options.defaultLocale;
+    }
+    else {
+        this.warn('The `defaultLocale` option should be a string');
+        this.defaultLocale = '';
+    }
 
     // Set debug flag
     if ('debug' in options) {
@@ -133,7 +144,7 @@ Gettext.prototype.setLocale = function(locale) {
         this.warn('You called setLocale() with an empty value, which makes little sense.');
     }
 
-    if (!this.catalogs[locale]) {
+    if (locale !== this.defaultLocale && !this.catalogs[locale]) {
         this.warn('You called setLocale() with "' + locale + '", but no translations for that locale has been added.');
     }
 
@@ -306,7 +317,7 @@ Gettext.prototype.dnpgettext = function(domain, msgctxt, msgid, msgidPlural, cou
 
         return translation.msgstr[index] || defaultTranslation;
     }
-    else {
+    else if (!this.defaultLocale || this.locale !== this.defaultLocale) {
         this.warn('No translation was found for msgid "' + msgid + '" in msgctxt "' + msgctxt + '" and domain "' + domain + '"');
     }
 

--- a/test/gettext-test.js
+++ b/test/gettext-test.js
@@ -17,6 +17,40 @@ describe('Gettext', function() {
         jsonFile = JSON.parse(fs.readFileSync(__dirname + '/fixtures/latin13.json'));
     });
 
+    describe('#constructor', function() {
+        var gtc;
+
+        beforeEach(function() {
+            gtc = null;
+        });
+
+        describe('#defaultLocale option', function() {
+            it('should accept any string as a locale', function() {
+                gtc = new Gettext({ defaultLocale: 'en-US' });
+                expect(gtc.defaultLocale).to.equal('en-US');
+                gtc = new Gettext({ defaultLocale: '01234' });
+                expect(gtc.defaultLocale).to.equal('01234');
+            });
+
+            it('should default to en empty string', function() {
+                expect((new Gettext()).defaultLocale).to.equal('');
+            });
+
+            it('should reject non-string values', function() {
+                gtc = new Gettext({ defaultLocale: null });
+                expect(gtc.defaultLocale).to.equal('');
+                gtc = new Gettext({ defaultLocale: 123 });
+                expect(gtc.defaultLocale).to.equal('');
+                gtc = new Gettext({ defaultLocale: false });
+                expect(gtc.defaultLocale).to.equal('');
+                gtc = new Gettext({ defaultLocale: {} });
+                expect(gtc.defaultLocale).to.equal('');
+                gtc = new Gettext({ defaultLocale: function() {} });
+                expect(gtc.defaultLocale).to.equal('');
+            });
+        });
+    });
+
     describe('#getLanguageCode', function() {
         it('should normalize locale string', function() {
             expect(Gettext.getLanguageCode('ab-cd_ef.utf-8')).to.equal('ab');
@@ -252,6 +286,15 @@ describe('Gettext', function() {
             gt.setLocale('et-EE');
             gt.gettext('o2-1');
             expect(errorListener.callCount).to.equal(0);
+        });
+
+        it('should not emit any error events when the current locale is the default locale', function() {
+            var gtd = new Gettext({ defaultLocale: 'en-US' });
+            var errorListenerDefaultLocale = sinon.spy();
+            gtd.on('error', errorListenerDefaultLocale);
+            gtd.setLocale('en-US');
+            gtd.gettext('This message is not translated');
+            expect(errorListenerDefaultLocale.callCount).to.equal(0);
         });
     });
 


### PR DESCRIPTION
Since the strings defined in the source are likely in the default language, one should be able use that locale without errors.

* `setLocale` doesn't have to warn about missing translaitons.
* The translation function calls don't have to warn about non-tranlated messages.

I feel that this should be a constructor option rather than a method like `setLocale`, since changing it dynamically shouldn't be needed. This made the tests a bit awkward though, do you want them structured some other way? I'm not really used to OOP testing.