### PR TITLE
fix typo in - setLomain to setLocale

### DIFF
--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -392,7 +392,7 @@ Gettext.prototype.textdomain = function(domain) {
  * @see Gettext#setLocale
  */
 Gettext.prototype.setlocale = function(locale) {
-    this.setLomain(locale);
+    this.setLocale(locale);
 };
 
 /* Deprecated functions */


### PR DESCRIPTION
I just found small typo in the code. setlocale legacy function calls setLomain which does not exit