### PR TITLE
corrected Slovenian plural forms

### DIFF
--- a/lib/plurals.js
+++ b/lib/plurals.js
@@ -1699,22 +1699,22 @@ module.exports = {
     sl: {
         name: 'Slovenian',
         examples: [{
-            plural: 1,
+            plural: 0,
             sample: 1
         }, {
-            plural: 2,
+            plural: 1,
             sample: 2
         }, {
-            plural: 3,
+            plural: 2,
             sample: 3
         }, {
-            plural: 0,
+            plural: 3,
             sample: 5
         }],
         nplurals: 4,
-        pluralsText: 'nplurals = 4; plural = (n % 100 === 1 ? 1 : n % 100 === 2 ? 2 : n % 100 === 3 || n % 100 === 4 ? 3 : 0)',
+        pluralsText: 'nplurals = 4; plural = (n % 100 === 1 ? 0 : n % 100 === 2 ? 1 : n % 100 === 3 || n % 100 === 4 ? 2 : 3)',
         pluralsFunc: function(n) {
-            return (n % 100 === 1 ? 1 : n % 100 === 2 ? 2 : n % 100 === 3 || n % 100 === 4 ? 3 : 0);
+            return (n % 100 === 1 ? 0 : n % 100 === 2 ? 1 : n % 100 === 3 || n % 100 === 4 ? 2 : 3);
         }
     },
     so: {


### PR DESCRIPTION
As common used plural form which is used widely is different I am committing corrected one:

93 datotek je odstranjenih
94 datotek je odstranjenih
95 datotek je odstranjenih
96 datotek je odstranjenih
97 datotek je odstranjenih
98 datotek je odstranjenih
99 datotek je odstranjenih
100 datotek je odstranjenih
101 datoteka je odstranjena
102 datoteki sta odstranjeni
103 datoteke so odstranjene
104 datoteke so odstranjene
105 datotek je odstranjenih
106 datotek je odstranjenih
107 datotek je odstranjenih
108 datotek je odstranjenih

not like it was:

87 datoteka je odstranjena
88 datoteka je odstranjena
89 datoteka je odstranjena
90 datoteka je odstranjena
91 datoteka je odstranjena
92 datoteka je odstranjena
93 datoteka je odstranjena
94 datoteka je odstranjena
95 datoteka je odstranjena
96 datoteka je odstranjena
97 datoteka je odstranjena
98 datoteka je odstranjena
99 datoteka je odstranjena
100 datoteka je odstranjena
101 datoteki sta odstranjeni
102 datoteke so odstranjene
103 datotek je odstranjenih
104 datotek je odstranjenih
105 datoteka je odstranjena
106 datoteka je odstranjena
107 datoteka je odstranjena

Please add in next version.